### PR TITLE
dockerize kibana

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# ignore kibana source
+src/

--- a/.solo/kibana.json
+++ b/.solo/kibana.json
@@ -1,0 +1,5 @@
+{
+  "ports": [ 5601 ],
+  "start_container": "bin/start_kibana_docker",
+  "start_process": "bin/start_kibana"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM socrata/runit-nodejs
+
+# $docker_version and $service_suffix should be passed here using the --build-arg flag
+# configure this in the dockerize jenkins task with DOCKER_BUILD_ARGS
+ARG docker_version
+ARG service_suffix
+
+# required until runit base image correctly sets ark_host
+ENV ARK_HOST aws-private
+ENV LOG_LEVEL info
+
+ENV APP kibana
+ENV SERVICE_SUFFIX $service_suffix
+ENV KIBANA_SOURCE src
+ENV CONFIG ${APP}.yml
+ENV ROOT_DIR /srv/${APP}/
+ENV SERVICE_DIR /etc/service
+ENV APP_DIR /etc/service/${APP}
+ENV SERVICE_PORT 5601
+
+RUN apt-get update && apt-get install -y wget
+
+# get the source
+COPY download_kibana.sh $SERVICE_DIR
+RUN cd $SERVICE_DIR && $SERVICE_DIR/download_kibana.sh $docker_version
+RUN rm $SERVICE_DIR/download_kibana.sh
+
+# cleanup
+RUN chown --recursive socrata $APP_DIR
+RUN rm $APP_DIR/config/*
+
+# finish setup
+COPY runit $APP_DIR
+COPY $CONFIG.j2 $APP_DIR/config/$CONFIG.j2
+
+RUN chown socrata $APP_DIR/config/$CONFIG.j2
+
+EXPOSE ${SERVICE_PORT}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
 # Kibana
+
+Kibana is your window into the [Elastic Stack](https://www.elastic.co/products). Specifically, it's a browser-based analytics and search dashboard for Elasticsearch.
+
+- [Getting Started](#getting-started)
+  - [Using a Kibana Release](#using-a-kibana-release)
+  - [Building and Running Kibana, and/or Contributing Code](#building-and-running-kibana-andor-contributing-code)
+- [Documentation](#documentation)
+- [Version Compatibility with Elasticsearch](#version-compatibility-with-elasticsearch)
+- [Questions? Problems? Suggestions?](#questions-problems-suggestions)
+
+## Getting Started
+
+If you just want to try Kibana out, check out the [Elastic Stack Getting Started Page](https://www.elastic.co/start) to give it a whirl.
+
+If you're interested in diving a bit deeper and getting a taste of Kibana's capabilities, head over to the [Kibana Getting Started Page](https://www.elastic.co/guide/en/kibana/current/getting-started.html).
+
+### Using a Kibana Release
+
+If you want to use a Kibana release in production, give it a test run, or just play around:
+
+- Download the latest version on the [Kibana Download Page](https://www.elastic.co/downloads/kibana).
+- Learn more about Kibana's features and capabilities on the
+[Kibana Product Page](https://www.elastic.co/products/kibana).
+- We also offer a hosted version of Kibana on our
+[Cloud Service](https://www.elastic.co/cloud/as-a-service).
+
+### Building and Running Kibana, and/or Contributing Code
+
+You might want to build Kibana locally to contribute some code, test out the latest features, or try
+out an open PR:
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) will help you get Kibana up and running.
+- If you would like to contribute code, please follow our [STYLEGUIDE.md](STYLEGUIDE.md).
+- Learn more about our UI code with [UI_SYSTEMS.md](src/legacy/ui/public/UI_SYSTEMS.md).
+- For all other questions, check out the [FAQ.md](FAQ.md) and
+[wiki](https://github.com/elastic/kibana/wiki).
+
+## Documentation
+
+Visit [Elastic.co](http://www.elastic.co/guide/en/kibana/current/index.html) for the full Kibana documentation.
+
+For information about building the documentation, see the README in [elastic/docs](https://github.com/elastic/docs).
+
+## Version Compatibility with Elasticsearch
+
+Ideally, you should be running Elasticsearch and Kibana with matching version numbers. If your Elasticsearch has an older version number or a newer _major_ number than Kibana, then Kibana will fail to run. If Elasticsearch has a newer minor or patch number than Kibana, then the Kibana Server will log a warning.
+
+_Note: The version numbers below are only examples, meant to illustrate the relationships between different types of version numbers._
+
+| Situation                 | Example Kibana version     | Example ES version | Outcome |
+| ------------------------- | -------------------------- |------------------- | ------- |
+| Versions are the same.    | 5.1.2                      | 5.1.2              | 💚 OK      |
+| ES patch number is newer. | 5.1.__2__                  | 5.1.__5__          | ⚠️ Logged warning      |
+| ES minor number is newer. | 5.__1__.2                  | 5.__5__.0          | ⚠️ Logged warning      |
+| ES major number is newer. | __5__.1.2                  | __6__.0.0          | 🚫 Fatal error      |
+| ES patch number is older. | 5.1.__2__                  | 5.1.__0__          | ⚠️ Logged warning      |
+| ES minor number is older. | 5.__1__.2                  | 5.__0__.0          | 🚫 Fatal error      |
+| ES major number is older. | __5__.1.2                  | __4__.0.0          | 🚫 Fatal error      |
+
+## Questions? Problems? Suggestions?
+
+- If you've found a bug or want to request a feature, please create a [GitHub Issue](https://github.com/elastic/kibana/issues/new).
+Please check to make sure someone else hasn't already created an issue for the same topic.
+- Need help using Kibana? Ask away on our [Kibana Discuss Forum](https://discuss.elastic.co/c/kibana) and a fellow community member or
+Elastic engineer will be glad to help you out.
+

--- a/README.md
+++ b/README.md
@@ -1,78 +1,31 @@
-# Kibana at Socrata
-
-We use Kibana to monitor [catalog service](https://github.com/socrata/catalog-service)'s
-elastic search cluster as well as [spandex](https://github.com/socrata-platform/spandex)'s
-autocomplete cluster. This repository doesn't contain the source for Kibana. It
-exists so that we can build our own kibana docker image with jenkins for
-deployment to whatever environment.
-
-*NOTE:* everything from this point on is taken from Elastic's public [Kibana
-repository](https://github.com/elastic/kibana).
-
 # Kibana
 
-Kibana is your window into the [Elastic Stack](https://www.elastic.co/products). Specifically, it's a browser-based analytics and search dashboard for Elasticsearch.
+We use Kibana to monitor the [catalog
+service](https://github.com/socrata/catalog-service) and
+[spandex](https://github.com/socrata-platform/spandex) Elasticsearch clusters.
+This repository doesn't contain the source for Kibana. It exists so that we can
+build our own Kibana docker image with Jenkins for deployment to whatever
+environment.
 
-- [Getting Started](#getting-started)
-  - [Using a Kibana Release](#using-a-kibana-release)
-  - [Building and Running Kibana, and/or Contributing Code](#building-and-running-kibana-andor-contributing-code)
-- [Documentation](#documentation)
-- [Version Compatibility with Elasticsearch](#version-compatibility-with-elasticsearch)
-- [Questions? Problems? Suggestions?](#questions-problems-suggestions)
+To learn more about Kibana, check out Elastic's [Kibana
+repository](https://github.com/elastic/kibana).
 
 ## Getting Started
 
-If you just want to try Kibana out, check out the [Elastic Stack Getting Started Page](https://www.elastic.co/start) to give it a whirl.
+If you'd like to start and stop Kibana with [solo](https://github.com/socrata/solo)
+then run `solo register` from the root of this repository. Now you'll be able to
+run `solo start kibana` or `solo start kibana --container`. The former will
+download the kibana source in the `src` dir at the root of this repository,
+where the latter will pull a docker imag from our `internal/kibana` ecr
+repository.
 
-If you're interested in diving a bit deeper and getting a taste of Kibana's capabilities, head over to the [Kibana Getting Started Page](https://www.elastic.co/guide/en/kibana/current/getting-started.html).
+## Making Changes
 
-### Using a Kibana Release
-
-If you want to use a Kibana release in production, give it a test run, or just play around:
-
-- Download the latest version on the [Kibana Download Page](https://www.elastic.co/downloads/kibana).
-- Learn more about Kibana's features and capabilities on the
-[Kibana Product Page](https://www.elastic.co/products/kibana).
-- We also offer a hosted version of Kibana on our
-[Cloud Service](https://www.elastic.co/cloud/as-a-service).
-
-### Building and Running Kibana, and/or Contributing Code
-
-You might want to build Kibana locally to contribute some code, test out the latest features, or try
-out an open PR:
-
-- [CONTRIBUTING.md](CONTRIBUTING.md) will help you get Kibana up and running.
-- If you would like to contribute code, please follow our [STYLEGUIDE.md](STYLEGUIDE.md).
-- Learn more about our UI code with [UI_SYSTEMS.md](src/legacy/ui/public/UI_SYSTEMS.md).
-- For all other questions, check out the [FAQ.md](FAQ.md) and
-[wiki](https://github.com/elastic/kibana/wiki).
-
-## Documentation
-
-Visit [Elastic.co](http://www.elastic.co/guide/en/kibana/current/index.html) for the full Kibana documentation.
-
-For information about building the documentation, see the README in [elastic/docs](https://github.com/elastic/docs).
-
-## Version Compatibility with Elasticsearch
-
-Ideally, you should be running Elasticsearch and Kibana with matching version numbers. If your Elasticsearch has an older version number or a newer _major_ number than Kibana, then Kibana will fail to run. If Elasticsearch has a newer minor or patch number than Kibana, then the Kibana Server will log a warning.
-
-_Note: The version numbers below are only examples, meant to illustrate the relationships between different types of version numbers._
-
-| Situation                 | Example Kibana version     | Example ES version | Outcome |
-| ------------------------- | -------------------------- |------------------- | ------- |
-| Versions are the same.    | 5.1.2                      | 5.1.2              | 💚 OK      |
-| ES patch number is newer. | 5.1.__2__                  | 5.1.__5__          | ⚠️ Logged warning      |
-| ES minor number is newer. | 5.__1__.2                  | 5.__5__.0          | ⚠️ Logged warning      |
-| ES major number is newer. | __5__.1.2                  | __6__.0.0          | 🚫 Fatal error      |
-| ES patch number is older. | 5.1.__2__                  | 5.1.__0__          | ⚠️ Logged warning      |
-| ES minor number is older. | 5.__1__.2                  | 5.__0__.0          | 🚫 Fatal error      |
-| ES major number is older. | __5__.1.2                  | __4__.0.0          | 🚫 Fatal error      |
-
-## Questions? Problems? Suggestions?
-
-- If you've found a bug or want to request a feature, please create a [GitHub Issue](https://github.com/elastic/kibana/issues/new).
-Please check to make sure someone else hasn't already created an issue for the same topic.
-- Need help using Kibana? Ask away on our [Kibana Discuss Forum](https://discuss.elastic.co/c/kibana) and a fellow community member or
-Elastic engineer will be glad to help you out.
+If you plan to make changes to the kibana application in any of our
+environments, you may want to take a look at
+- [apps marathon](https://github.com/socrata/apps-marathon/)
+  - look for `json` / `toml` files named `kibana-catalog` or `kibana-spandex`. 
+- [jenkinks > jobs > kibana](https://jenkins-build.socrata.com/job/kibana/)
+  - there are a few command line arguments that the `kibana` job passes to the
+    `dockerize` job that distinguish the spandex and catalog builds
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+# Kibana at Socrata
+
+We use Kibana to monitor [catalog service](https://github.com/socrata/catalog-service)'s
+elastic search cluster as well as [spandex](https://github.com/socrata-platform/spandex)'s
+autocomplete cluster. This repository doesn't contain the source for Kibana. It
+exists so that we can build our own kibana docker image with jenkins for
+deployment to whatever environment.
+
+*NOTE:* everything from this point on is taken from Elastic's public [Kibana
+repository](https://github.com/elastic/kibana).
+
 # Kibana
 
 Kibana is your window into the [Elastic Stack](https://www.elastic.co/products). Specifically, it's a browser-based analytics and search dashboard for Elasticsearch.

--- a/bin/start_kibana
+++ b/bin/start_kibana
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+cd $(dirname $BASH_SOURCE[0])
+cd ..
+
+if [ ! -d "src" ]; then
+  ./download_kibana.sh 7.3.0
+  mv kibana/ src/
+fi
+
+cd src
+
+./bin/kibana

--- a/bin/start_kibana_docker
+++ b/bin/start_kibana_docker
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+image="$1"
+
+if [ -z "$image" ]; then
+  echo "ERR >> Please supply a full image name as an argument to this script!"
+  exit 1
+fi
+
+AWS_PROFILE=infrastructure docker run \
+  --network host \
+  -p 5601:5601 \
+  "$image"

--- a/download_kibana.sh
+++ b/download_kibana.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+version="$1"
+
+if [ -z $version ]; then
+    echo "You must specify a Kibana version at positional argument!"
+    exit 666
+fi
+
+# TODO : parameterize version
+wget "https://artifacts.elastic.co/downloads/kibana/kibana-${version}-linux-x86_64.tar.gz"
+
+# get sha512 checksum (make sure there's no newline at the end of the file)
+echo -n "$(sha512sum kibana-${version}-linux-x86_64.tar.gz)" > src.sha512
+
+wget "https://artifacts.elastic.co/downloads/kibana/kibana-${version}-linux-x86_64.tar.gz.sha512"
+mv kibana-${version}-linux-x86_64.tar.gz.sha512 truth.sha512
+checksum_diff=$(diff src.sha512 truth.sha512)
+
+# do not extract tarball if checksums differ!
+if [[ -z "$d" ]]; then
+    echo "extracting kibana..."
+    tar -xf kibana-${version}-linux-x86_64.tar.gz
+    mv kibana-${version}-linux-x86_64/ kibana
+
+else
+    echo "ERROR: checksums differ - extraction terminated"
+fi
+
+# cleanup
+rm src.sha512 truth.sha512 kibana-${version}-linux-x86_64.tar.gz
+
+exit 0

--- a/kibana.yml.j2
+++ b/kibana.yml.j2
@@ -1,0 +1,4 @@
+elasticsearch.hosts: ["http://{{ ES_HOST }}"]
+elasticsearch.username: "{{ ES_USERNAME }}"
+elasticsearch.password: "{{ ES_PASSWORD }}"
+server.host: 0.0.0.0

--- a/runit/run
+++ b/runit/run
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ ! -z "$MARATHON_APP_ID" ]; then
+    source /dev/shm/kibana-${SERVICE_SUFFIX}-env
+fi
+
+set -ev
+
+if [ ! -z "$MARATHON_APP_ID" ]; then
+    . /bin/set_ark_host
+    /bin/env_parse /etc/service/kibana/config/${CONFIG}.j2
+fi
+
+exec su socrata -c "/etc/service/kibana/bin/kibana"

--- a/runit/run
+++ b/runit/run
@@ -9,6 +9,9 @@ set -ev
 if [ ! -z "$MARATHON_APP_ID" ]; then
     . /bin/set_ark_host
     /bin/env_parse /etc/service/kibana/config/${CONFIG}.j2
+else
+    echo "" > /etc/service/kibana/config/${CONFIG}
+    rm /etc/service/kibana/config/${CONFIG}.j2
 fi
 
 exec su socrata -c "/etc/service/kibana/bin/kibana"


### PR DESCRIPTION
# What is this?
We use Kibana to monitor [catalog service](https://github.com/socrata/catalog-service)'s elastic search cluster as well as [spandex](https://github.com/socrata-platform/spandex)'s autocomplete cluster. This repository doesn't contain the source for Kibana. It exists so that we can build our own kibana docker image with jenkins for deployment to whatever environment.  

# Context
- [Jenkins job](jenkins-build.socrata.com/job/app)
- [JIRA ticket](https://socrata.atlassian.net/browse/EN-34920)

# What do these changes amount to?
- dockerfile to build our own docker image for kibana
  - don't track the kibana source tho, it's just too much!
- download_kibana.sh downloads kibana in container or locally
  - version is parameterized to make download script extensible
- solo file to tell solo how to interact with kibana (process and container)
- start script for process and container
