### PR TITLE
EN-34920 runit checks for spandex and catalog clortho creds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,14 @@
 FROM socrata/runit-nodejs
 
-# $docker_version and $service_suffix should be passed here using the --build-arg flag
+# $docker_version should be passed here using the --build-arg flag
 # configure this in the dockerize jenkins task with DOCKER_BUILD_ARGS
 ARG docker_version
-ARG service_suffix
 
 # required until runit base image correctly sets ark_host
 ENV ARK_HOST aws-private
 ENV LOG_LEVEL info
 
 ENV APP kibana
-ENV SERVICE_SUFFIX $service_suffix
 ENV KIBANA_SOURCE src
 ENV CONFIG ${APP}.yml
 ENV ROOT_DIR /srv/${APP}/

--- a/README.md
+++ b/README.md
@@ -29,3 +29,9 @@ environments, you may want to take a look at
   - there are a few command line arguments that the `kibana` job passes to the
     `dockerize` job that distinguish the spandex and catalog builds
 
+If you are making changes to the docker image, you'll probably want to build a
+local image with this command:
+
+```
+docker build -t "kibana:test_build" --build-arg docker_version=7.3.2 .
+```

--- a/runit/run
+++ b/runit/run
@@ -1,7 +1,17 @@
 #!/bin/bash
 
 if [ ! -z "$MARATHON_APP_ID" ]; then
-    source /dev/shm/kibana-${SERVICE_SUFFIX}-env
+
+    if [ -f /dev/shm/kibana-catalog-env ]; then
+        source /dev/shm/kibana-catalog-env
+    elif [ -f /dev/shm/kibana-spandex-env ]; then
+        source /dev/shm/kibana-spandex-env
+    else
+        echo "-----------------------------"
+        echo "ERROR: no clortho file found!"
+        echo "-----------------------------"
+    fi
+
 fi
 
 set -ev


### PR DESCRIPTION
this allows us to use the same docker image for either apps-marathon app
also update the readme with `docker build` command